### PR TITLE
Fix typo in CLI response output

### DIFF
--- a/run_cli.py
+++ b/run_cli.py
@@ -54,7 +54,7 @@ async def chat(context: AgentContext):
         assistant_response = await context.communicate(UserMessage(user_input, [])).result()
         
         # print agent0 response
-        PrintStyle(font_color="white",background_color="#1D8348", bold=True, padding=True).print(f"{context.agent0.agent_name}: reponse:")        
+        PrintStyle(font_color="white",background_color="#1D8348", bold=True, padding=True).print(f"{context.agent0.agent_name}: response:")
         PrintStyle(font_color="white").print(f"{assistant_response}")        
                         
 


### PR DESCRIPTION
## Summary
- fix a small typo in run_cli

## Testing
- `python -m py_compile run_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68418a8670f8832da694b667fe1c9a58