### PR TITLE
Fix get_server unused parameter

### DIFF
--- a/python/helpers/process.py
+++ b/python/helpers/process.py
@@ -9,7 +9,7 @@ def set_server(server):
     global _server
     _server = server
 
-def get_server(server):
+def get_server():
     global _server
     return _server
 


### PR DESCRIPTION
## Summary
- remove unused parameter from `get_server`

## Testing
- `python3 -m py_compile python/helpers/process.py`

------
https://chatgpt.com/codex/tasks/task_e_684188536e54832db9a54919db502e9a